### PR TITLE
fix market entity type after update

### DIFF
--- a/assets/scar/diplomacy/ags_diplomacy.scar
+++ b/assets/scar/diplomacy/ags_diplomacy.scar
@@ -231,7 +231,7 @@ function AGS_Diplomacy_Create(relations)
 			style = ECV_Queue,
 		},
 		entity_type = {
-			market = "market",
+			market = "scar_market",
 		},
 		tribute = {
 			is_age_2 = true,						--false check removed used to calculate data_context.is_tribute_enabled				


### PR DESCRIPTION
Since the latest Season 5 update Update 7.0.5861, tributing has been broken for the AGS gameplay mod. This change fixes the issue. I have run and tested this change locally. 